### PR TITLE
Fix cleaning logic in deploy script

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -91,7 +91,7 @@ build_and_deploy() {
     fi
     git checkout --detach "${base_commit}"
     rm ./.git/index
-    git reset --hard
+    git clean -fdx
     # Explode the `build/` directory into the current directory.
     find "${sourcecred_repo}/build/" -mindepth 1 -maxdepth 1 \
         \( -name .git -prune \) -o \


### PR DESCRIPTION
Summary:
The sequence `rm .git/index; git reset --hard` was intended to remove
all files in the work tree. But it actually was effectively a no-op: it
cleared the index, and then reset to the previous commit, not the empty
index. The behavior was the same for the initial commit, because the
parent deploy was empty, but for subsequent deploys this caused a
failure due to the previous build not having been removed.

Test Plan:
Run `./deploy.sh -n`, which fails before this commit and passes after
it.

wchargin-branch: fix-cleaning