### PR TITLE
Clean quietly

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -91,7 +91,7 @@ build_and_deploy() {
     fi
     git checkout --detach "${base_commit}"
     rm ./.git/index
-    git clean -fdx
+    git clean -qfdx
     # Explode the `build/` directory into the current directory.
     find "${sourcecred_repo}/build/" -mindepth 1 -maxdepth 1 \
         \( -name .git -prune \) -o \


### PR DESCRIPTION
Summary:
This just suppresses some potentially alarming noise, in that the build
script says that lots of things are being deleted before they’re being
re-added.

wchargin-branch: clean-quietly