### PR TITLE
Generate example data for sourcecred/sourcecred

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -79,6 +79,7 @@ build_and_deploy() {
         yarn build
         node ./bin/sourcecred.js load sourcecred example-github
         node ./bin/sourcecred.js load sourcecred example-git
+        node ./bin/sourcecred.js load sourcecred sourcecred
     )
 
     git fetch -q "${REMOTE}"


### PR DESCRIPTION
Test Plan:
Running `./deploy.sh -n` works. It now takes about 1m30s.

wchargin-branch: data--sourcecred-sourcecred